### PR TITLE
Account for JSON files without versioning + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ jobs:
 
       # getting the path of the flow definition that changed (only one expected for now)
       - id: files
-        uses: Ana06/get-changed-files@v1.2
+        uses: tj-actions/changed-files@v45
+        with:
+          since_last_remote_commit: true
+          files: |
+            **/*.json
 
       # checking out the code without the change of the PR
       - name: Checkout original code

--- a/flow-diff/src/main/java/com/snowflake/openflow/FlowDiff.java
+++ b/flow-diff/src/main/java/com/snowflake/openflow/FlowDiff.java
@@ -66,7 +66,7 @@ public class FlowDiff {
 
         System.out.println("> [!NOTE]");
         System.out.println("> This GitHub Action is created and maintained by [Snowflake](https://www.snowflake.com/).");
-        System.out.println("### Executing Datavolo Flow Diff for flow: `" + flowName + "`");
+        System.out.println("### Executing Snowflake Flow Diff for flow: " + flowName);
 
         for(FlowDifference diff : diffs) {
 
@@ -393,7 +393,13 @@ public class FlowDiff {
                 FlowComparatorVersionedStrategy.DEEP
             );
 
-        flowName = snapshotA.getFlowSnapshot().getFlow().getName();
+        if (snapshotA.getFlowSnapshot().getFlow() != null) {
+            flowName = "`" + snapshotA.getFlowSnapshot().getFlow().getName() + "`";
+        } else if (snapshotB.getFlowSnapshot().getFlow() != null) {
+            flowName = "`" + snapshotB.getFlowSnapshot().getFlow().getName() + "`";
+        } else {
+            flowName = "";
+        }
         parameterContexts = snapshotB.getFlowSnapshot().getParameterContexts();
 
         final SortedSet<FlowDifference> sortedDiffs = new TreeSet(new Comparator<FlowDifference>() {


### PR DESCRIPTION
This PR:
- accounts for the possibility where the JSON file does not contain versioning information (it happens when downloading the JSON file from the NiFi UI at process group level)
- removes a reference to Datavolo instead of Snowflake
- replaces the example in the README with an action to get the changed files that is more actively maintained