### PR TITLE
Replace tabs with whitespaces

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@
 
 java -jar /flow-diff.jar $1 $2 >> /github/workspace/diff.txt
 
-OUTPUT=$(cat /github/workspace/diff.txt | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+OUTPUT=$(cat /github/workspace/diff.txt | sed 's/"/\\"/g' | sed 's/\t/    /g' | sed ':a;N;$!ba;s/\n/\\n/g')
 
 curl -X POST \
      -H "Authorization: Token $3" \


### PR DESCRIPTION
If a property contains tab characters, it'll cause an invalid JSON to be sent to the Github API. This PR improves handling of the diff output to create a proper JSON to be sent to the Github API.

If additional similar issues are faced in the future, we may want to consider adding a dependency in the code to handle the JSON object creation directly in the code and remove this scripting completely.