### PR TITLE
Add checkstyle rule for missing flow snapshot metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ To enable checkstyle:
         uses: snowflake-labs/snowflake-flow-diff@v0
         id: flowdiff
         with:
-          flowA: 'original-code/${{ steps.files.outputs.all_changed_files }}'
-          flowB: 'submitted-changes/${{ steps.files.outputs.all_changed_files }}'
+          flowA: ${{ steps.files.outputs.flowA }}
+          flowB: ${{ steps.files.outputs.flowB }}
           checkstyle: true
 ```
 
@@ -98,7 +98,8 @@ Here is an example of what the comment could look like:
 ### Executing Snowflake Flow Diff for flow: `MyExample`
 
 #### Checkstyle Violations
-- Processor named `UpdateAttribute` is configured with 4 concurrent tasks
+> [!CAUTION]
+> - Processor named `UpdateAttribute` is configured with 4 concurrent tasks
 
 #### Flow Changes
 - The destination of a connection has changed from `UpdateAttribute` to `InvokeHTTP`

--- a/flow-diff/src/main/java/com/snowflake/openflow/FlowCheckstyle.java
+++ b/flow-diff/src/main/java/com/snowflake/openflow/FlowCheckstyle.java
@@ -18,18 +18,31 @@ package com.snowflake.openflow;
 
 import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.flow.VersionedProcessor;
+import org.apache.nifi.registry.flow.FlowSnapshotContainer;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class FlowCheckstyle {
 
-    public static List<String> getCheckstyleViolations(final VersionedProcessGroup flow) {
+    public static List<String> getCheckstyleViolations(final FlowSnapshotContainer flowSnapshotContainer) {
         final List<String> violations = new ArrayList<>();
+        VersionedProcessGroup rootProcessGroup = flowSnapshotContainer.getFlowSnapshot().getFlowContents();
 
         // check concurrent tasks
-        violations.addAll(checkConcurrentTasks(flow));
+        violations.addAll(checkConcurrentTasks(rootProcessGroup));
 
+        // check that snapshot metadata is present
+        violations.addAll(checkSnapshotMetadata(flowSnapshotContainer));
+
+        return violations;
+    }
+
+    private static List<String> checkSnapshotMetadata(FlowSnapshotContainer flowSnapshotContainer) {
+        final List<String> violations = new ArrayList<>();
+        if (flowSnapshotContainer.getFlowSnapshot().getSnapshotMetadata() == null) {
+            violations.add("Flow snapshot metadata is missing");
+        }
         return violations;
     }
 

--- a/flow-diff/src/main/java/com/snowflake/openflow/FlowCheckstyle.java
+++ b/flow-diff/src/main/java/com/snowflake/openflow/FlowCheckstyle.java
@@ -16,6 +16,7 @@
  */
 package com.snowflake.openflow;
 
+import org.apache.nifi.flow.VersionedParameter;
 import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.flow.VersionedProcessor;
 import org.apache.nifi.registry.flow.FlowSnapshotContainer;
@@ -34,6 +35,27 @@ public class FlowCheckstyle {
 
         // check that snapshot metadata is present
         violations.addAll(checkSnapshotMetadata(flowSnapshotContainer));
+
+        // check that no parameter is set to empty string
+        violations.addAll(checkEmptyParameters(flowSnapshotContainer));
+
+        return violations;
+    }
+
+    private static List<String> checkEmptyParameters(FlowSnapshotContainer flowSnapshotContainer) {
+        final List<String> violations = new ArrayList<>();
+        final List<VersionedParameter> parameters = flowSnapshotContainer.getFlowSnapshot()
+                .getParameterContexts()
+                .values()
+                .stream()
+                .flatMap(context -> context.getParameters().stream())
+                .toList();
+
+        for (VersionedParameter parameter : parameters) {
+            if (parameter.getValue() != null && parameter.getValue().isEmpty()) {
+                violations.add("Parameter named `" + parameter.getName() + "` is set to empty string");
+            }
+        }
 
         return violations;
     }

--- a/flow-diff/src/main/java/com/snowflake/openflow/FlowDiff.java
+++ b/flow-diff/src/main/java/com/snowflake/openflow/FlowDiff.java
@@ -102,8 +102,9 @@ public class FlowDiff {
 
         if (checkstyleEnabled && checkstyleViolations != null && !checkstyleViolations.isEmpty()) {
             System.out.println("#### Checkstyle Violations");
+            System.out.println("> [!CAUTION]");
             for (String violation : checkstyleViolations) {
-                System.out.println("- " + violation);
+                System.out.println("> - " + violation);
             }
             System.out.println("");
         }
@@ -475,7 +476,7 @@ public class FlowDiff {
         registerProcessGroups(rootPG);
 
         if (checkstyleEnabled) {
-            checkstyleViolations = FlowCheckstyle.getCheckstyleViolations(rootPG);
+            checkstyleViolations = FlowCheckstyle.getCheckstyleViolations(snapshotB);
         }
 
         if (noOriginalFlow) {

--- a/flow-diff/src/test/resources/flow_v6_parameter_value.json
+++ b/flow-diff/src/test/resources/flow_v6_parameter_value.json
@@ -140,7 +140,7 @@
       },
       "comments" : "",
       "componentType" : "PROCESSOR",
-      "concurrentlySchedulableTaskCount" : 1,
+      "concurrentlySchedulableTaskCount" : 5,
       "executionNode" : "ALL",
       "groupIdentifier" : "flow-contents-group",
       "identifier" : "1a59f65f-8b3a-3db9-982e-e0d334bd7e9c",
@@ -633,10 +633,5 @@
       } ]
     }
   },
-  "parameterProviders" : { },
-  "snapshotMetadata" : {
-    "author" : "pvillard@datavolo.io",
-    "flowIdentifier" : "test",
-    "timestamp" : 0
-  }
+  "parameterProviders" : { }
 }

--- a/flow-diff/src/test/resources/flow_v6_parameter_value.json
+++ b/flow-diff/src/test/resources/flow_v6_parameter_value.json
@@ -618,7 +618,7 @@
         "name" : "secured",
         "provided" : false,
         "sensitive" : false,
-		"value": ""
+        "value": ""
       } ]
     },
     "Test Parameter Context" : {

--- a/flow-diff/src/test/resources/flow_v6_parameter_value.json
+++ b/flow-diff/src/test/resources/flow_v6_parameter_value.json
@@ -617,7 +617,8 @@
         "description" : "",
         "name" : "secured",
         "provided" : false,
-        "sensitive" : true
+        "sensitive" : false,
+		"value": ""
       } ]
     },
     "Test Parameter Context" : {


### PR DESCRIPTION
This PR
- adds a rule to raise a checkstyle violation when the flow snapshot metadata is missing
- fixes the README for consistency between multiflow support and checkstyle
- improves testing to validate checkstyle rules
- improves visual rendering of the checkstyle violations

Example:

#### Checkstyle Violations
> [!CAUTION]
> - Processor named `InvokeHTTP` is configured with 5 concurrent tasks
> - Flow snapshot metadata is missing