### PR TITLE
Add release workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and publish (e.g. v0.0.24)'
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Resolve version tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ jobs:
 
 Note - you may want to change `grep  '\.json$'` with a more specific pattern to match your specific requirements.
 
+## Docker Image
+
+Each release also publishes a Docker image to the [GitHub Container Registry](https://github.com/snowflake-labs/snowflake-flow-diff/pkgs/container/snowflake-flow-diff). This is useful when you want to run the tool directly — for example in a GitLab CI pipeline or locally — without relying on the GitHub Action wrapper.
+
+```
+ghcr.io/snowflake-labs/snowflake-flow-diff:latest
+ghcr.io/snowflake-labs/snowflake-flow-diff:v0.0.24
+```
+
+The image entrypoint accepts the same positional arguments as the action inputs, in this order: `flowA`, `flowB`, `token`, `repository`, `issuenumber`, `checkstyle`, `checkstyle-rules`, `checkstyle-fail`, `api-url`, `flow-graph`.
+
 ## GitHub Enterprise Server
 
 This action works with GitHub Enterprise Server (GHE) out of the box. The GitHub API URL is automatically detected via `github.api_url`. If you need to override it for any reason, you can explicitly set the `api-url` input:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` that builds and pushes the Docker image to GHCR (`ghcr.io/snowflake-labs/snowflake-flow-diff`) on every version tag push (`v*`)
- Includes a `workflow_dispatch` trigger so any existing tag can be published manually (useful for retroactively publishing the current latest release)
- Updates `README.md` with a new **Docker Image** section documenting the GHCR image coordinates and entrypoint argument order

## Test plan

- [ ] Merge and push a `v*` tag — confirm the workflow triggers and the image appears at `ghcr.io/snowflake-labs/snowflake-flow-diff`
- [ ] Trigger manually via **Actions → Release Docker Image → Run workflow** with an existing tag to retroactively publish the current release