### PR TITLE
Fix release workflow: lowercase image name for GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,6 @@ on:
         description: 'Tag to build and publish (e.g. v0.0.24)'
         required: true
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   docker:
     name: Build and push Docker image
@@ -46,6 +42,7 @@ jobs:
           else
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
+          echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -55,7 +52,7 @@ jobs:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -65,5 +62,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.tag }}
+            ${{ steps.version.outputs.image }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ on:
         description: 'Tag to build and publish (e.g. v0.0.24)'
         required: true
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   docker:
     name: Build and push Docker image
@@ -42,7 +45,7 @@ jobs:
           else
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
-          echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "image=${{ env.REGISTRY }}/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -52,7 +55,7 @@ jobs:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Fixes the release workflow introduced in #82: `github.repository` returns `Snowflake-Labs/snowflake-flow-diff` (mixed case), but GHCR requires all-lowercase image names
- The `Resolve version tag` step now also computes the image name by piping the repository name through `tr '[:upper:]' '[:lower:]'`

The resulting image tag is `ghcr.io/snowflake-labs/snowflake-flow-diff:<version>`.

## Test plan

- [ ] Trigger **Actions → Release Docker Image → Run workflow** manually after merge and confirm the image is pushed successfully to GHCR